### PR TITLE
Add build for 5.15.153 kernel version

### DIFF
--- a/.github/workflows/kernel-a13.yml
+++ b/.github/workflows/kernel-a13.yml
@@ -70,6 +70,8 @@ jobs:
             os_patch_level: "2024-07"
           - sub_level: "151"
             os_patch_level: "2024-08"
+          - sub_level: "153"
+            os_patch_level: "2024-09"
           - sub_level: "167"
             os_patch_level: "2024-11"
           - sub_level: "170"


### PR DESCRIPTION
Many Samsung users on OneUI 7 rely on kernel version 5.15.153.  
[This version](https://github.com/tiann/KernelSU/releases/download/v1.0.5/android13-5.15.153_2024-09-boot.img.gz) is also officially available in the releases section of the [KernelSU repository](https://github.com/tiann/KernelSU/releases/latest)

Adding this version ensures better compatibility and support for devices using the latest Samsung firmware.