### PR TITLE
android15-6.6: add min_kdp to fix bluetooth on 6.6 devices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,6 +294,27 @@ jobs:
           cp ../../kernel_patches/69_hide_stuff.patch ./
           patch -p1 --forward -F 3 < 69_hide_stuff.patch
 
+      - name: Fix WiFi and Bluetooth on Samsung 6.6 GKI devices
+        if: ${{ ( inputs.kernel_version == '6.6' ) }}
+        run: |
+          echo "[+] Adding Samsung KDP exported symbols to abi_gki_aarch64_galaxy"
+          SYMBOL_LIST=$CONFIG/common/android/abi_gki_aarch64_galaxy
+          echo "kdp_set_cred_non_rcu" >> $SYMBOL_LIST
+          echo "kdp_usecount_dec_and_test" >> $SYMBOL_LIST
+          echo "kdp_usecount_inc" >> $SYMBOL_LIST
+          echo "[+] Adding Samsung KDP exported symbols definition to abi_gki_aarch64.stg"
+          cd $CONFIG/common
+          PATCH="../../kernel_patches/samsung/min_kdp/add-min_kdp-symbols.patch"
+          if patch -p1 --dry-run < $PATCH; then
+            echo "[+] Successfully added Samsung KDP exported symbols definition to abi_gki_aarch64.stg"
+            patch -p1 --no-backup-if-mismatch < $PATCH
+          fi
+          echo "[+] Adding Samsung minimal KDP driver"
+          cd drivers
+          cp "../../../kernel_patches/samsung/min_kdp/min_kdp.c" min_kdp.c
+          echo "obj-y += min_kdp.o" >> Makefile
+
+
       - name: Add Configuration Settings
         run: |
           echo "Changing to configuration directory: $CONFIG..."


### PR DESCRIPTION
https://github.com/WildKernels/kernel_patches/pull/35 MUST BE MERGED FIRST.

This is a porting of https://github.com/tiann/KernelSU/pull/2688 to WildKernel GKI builds.

Fixes #138 

Why is this required?
For some unknown reason the shipped Bluetooth driver depends on these three Knox Kernel Data Protection (KDP) symbols. In normal conditions even when KDP is disabled they are part of the kernel image, they just call the built-in kernel function without any other KDP request.
Not having these functions will not allow the bluetooth.ko driver to be loaded and thus will break Bluetooth functionality. On MTK this has been confirmed to also break WiFi as well.

What does this pull request do?
This PR adds the 3 functions (kdp_set_cred_non_rcu, kdp_usecount_dec_and_test, kdp_usecount_inc) by adding a minimal KDP driver which provides the functions including just the non-KDP case. The driver is included during build time to the kernel source alongside with the symbol definitions.

Which devices are affected?
I know it might surprise someone but Galaxy A34 5G boots completely fine using the latest Android 15 6.6 KernelSU GKI. However it has this problem. I don't know if Galaxy S25 and Galaxy A56 are able to boot using a GKI but if they do they would have the same issue as well as they also ship the Bluetooth driver which depends on Knox KDP.