### PR TITLE
feat: integrate NoMount VFS hooks

### DIFF
--- a/.github/actions/nomount/action.yml
+++ b/.github/actions/nomount/action.yml
@@ -1,0 +1,60 @@
+name: 'Setup NoMount'
+description: 'Integrate NoMount VFS hooks and enable CONFIG_NOMOUNT'
+
+inputs:
+  kernel_version:
+    description: 'Kernel major/minor version (for example, 5.10 or 6.6)'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch and integrate NoMount
+      shell: bash
+      env:
+        KERNEL_VERSION: ${{ inputs.kernel_version }}
+      run: |
+        set -euo pipefail
+
+        KERNEL_DIR="${{ github.workspace }}/kernel/common"
+        NOMOUNT_DIR="${{ github.workspace }}/nomount"
+        NOMOUNT_REPO="https://github.com/maxsteeel/nomount.git"
+
+        case "$KERNEL_VERSION" in
+          5.10|5.15|6.1|6.6|6.12|6.18)
+            NOMOUNT_PATCH="nomount_${KERNEL_VERSION}_kernel_integration.patch"
+            ;;
+          *)
+            echo "Unsupported kernel version for NoMount: $KERNEL_VERSION" >&2
+            exit 1
+            ;;
+        esac
+
+        test -d "$KERNEL_DIR" || {
+          echo "Kernel source directory does not exist: $KERNEL_DIR" >&2
+          exit 1
+        }
+
+        rm -rf "$NOMOUNT_DIR"
+        git clone --depth=1 --branch master "$NOMOUNT_REPO" "$NOMOUNT_DIR"
+
+        test -f "$NOMOUNT_DIR/kernel/patches/$NOMOUNT_PATCH" || {
+          echo "NoMount patch is missing: $NOMOUNT_PATCH" >&2
+          exit 1
+        }
+        test -f "$NOMOUNT_DIR/kernel/src/nomount.c"
+        test -f "$NOMOUNT_DIR/kernel/src/nomount.h"
+
+        cp "$NOMOUNT_DIR/kernel/src/nomount.c" "$KERNEL_DIR/fs/nomount.c"
+        cp "$NOMOUNT_DIR/kernel/src/nomount.h" "$KERNEL_DIR/fs/nomount.h"
+
+        cd "$KERNEL_DIR"
+        patch --forward --batch -p1 < "$NOMOUNT_DIR/kernel/patches/$NOMOUNT_PATCH"
+
+        echo "NoMount integrated: $KERNEL_VERSION ($NOMOUNT_PATCH)"
+
+    - name: Enable NoMount in kernel defconfig
+      uses: ./.github/actions/set-kernel-config
+      with:
+        config_list: |
+          CONFIG_NOMOUNT=y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,12 @@ jobs:
         os_patch_level: ${{ inputs.os_patch_level }}
         sublevel: ${{ steps.extract.outputs.sublevel }}
 
+    - name: Setup NoMount
+      if: contains(inputs.feature_set, 'NOMOUNT') || inputs.feature_set == 'FULL'
+      uses: ./.github/actions/nomount
+      with:
+        kernel_version: ${{ inputs.kernel_version }}
+
     - name: Baseband Guard
       if: (contains(inputs.feature_set, 'BBG') || inputs.feature_set == 'FULL')
       uses: ./.github/actions/bbg

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ on:
         description: "Feature Set"
         type: choice
         options:
+          - KSUN+SUSFS+NOMOUNT
           - KSUN+SUSFS+BBG+NET+DS
           - KSUN+SUSFS+BBG
           - KSUN+SUSFS+NET
@@ -41,6 +42,7 @@ on:
           - KSUN+NET
           - KSUN+DS
           - KSUN
+          - NOMOUNT
           - NONE
           - FULL
         default: FULL


### PR DESCRIPTION
# Add NoMount Kernel Integration and Feature Options

## Summary

This PR integrates [NoMount](https://github.com/maxsteeel/nomount) into the kernel build workflow and exposes it as a selectable feature-set option.

NoMount is applied during the build after the kernel source has been downloaded and the common kernel fixes have been applied. The integration supports all kernel versions currently handled by this repository: Android GKI 5.10, 5.15, 6.1, 6.6, 6.12, and 6.18.

## What changed

### 1. Added a reusable NoMount composite action

Added `.github/actions/nomount/action.yml`.

The action:

1. Validates the requested kernel version.
2. Selects the matching version-specific NoMount integration patch.
3. Clones the NoMount repository at build time.
4. Verifies that the selected patch and NoMount source files are present.
5. Copies `nomount.c` and `nomount.h` into the kernel `fs/` directory.
6. Applies the corresponding kernel integration patch.
7. Enables `CONFIG_NOMOUNT=y` through the existing kernel configuration action.

Supported kernel-version mappings are:

| Kernel version | NoMount patch |
| --- | --- |
| 5.10 | `nomount_5.10_kernel_integration.patch` |
| 5.15 | `nomount_5.15_kernel_integration.patch` |
| 6.1 | `nomount_6.1_kernel_integration.patch` |
| 6.6 | `nomount_6.6_kernel_integration.patch` |
| 6.12 | `nomount_6.12_kernel_integration.patch` |
| 6.18 | `nomount_6.18_kernel_integration.patch` |

Unsupported kernel versions fail explicitly instead of silently producing a build without NoMount.

### 2. Integrated NoMount into the kernel build workflow

The build workflow now invokes the NoMount action after the KernelSU/SUSFS setup and before the remaining optional integrations.

NoMount is enabled when either of the following conditions is met:

- the selected `feature_set` contains `NOMOUNT`;
- the selected `feature_set` is `FULL`.

For other feature sets, the NoMount step is skipped and the existing behavior is preserved.

### 3. Added feature-set choices

The manual workflow now exposes two NoMount-related choices:

- `KSUN+SUSFS+NOMOUNT` — builds the standard KernelSU + SUSFS configuration with NoMount enabled;
- `NOMOUNT` — enables only the NoMount feature from the feature-set selection.

The existing `FULL` option also enables NoMount through the workflow condition described above.

## Build-time behavior

The action intentionally downloads NoMount during the workflow rather than vendoring a copy of its source into this repository. This keeps the integration aligned with the upstream NoMount project while retaining version-specific patch selection in the build system.

The action uses `set -euo pipefail` and performs file-existence checks before modifying the kernel tree. A missing patch, missing source file, missing kernel directory, or unsupported kernel version causes the build step to fail clearly.

The temporary NoMount checkout is placed at `${{ github.workspace }}/nomount` and is removed before cloning so that repeated action execution does not reuse stale source files.

## Compatibility and scope

- Existing feature sets that do not include `NOMOUNT` are unaffected.
- `FULL` now includes NoMount as part of the complete feature configuration.
- NoMount is enabled with `CONFIG_NOMOUNT=y`.
- The implementation follows the existing repository pattern for reusable composite actions and kernel configuration changes.
- No changes are made to the kernel sources in this repository; kernel files are modified only inside the CI workspace during a build.
