### PR TITLE
Disable user namespaces in Droidspaces config

### DIFF
--- a/.github/actions/droidspaces/action.yml
+++ b/.github/actions/droidspaces/action.yml
@@ -81,5 +81,4 @@ runs:
           CONFIG_BINFMT_MISC=y
           CONFIG_BINFMT_SCRIPT=y
           CONFIG_BINFMT_ELF=y
-          CONFIG_USER_NS=y
-
+          CONFIG_USER_NS=n


### PR DESCRIPTION
## Description

  Disabled the `CONFIG_USER_NS` option in the DroidSpaces kernel configuration.

  DroidSpaces no longer requires User Namespaces. Keeping this option enabled may also indirectly indicate that the
  kernel has been modified.

  ## Changes

  - Changed `CONFIG_USER_NS=y` to `CONFIG_USER_NS=n`