### PR TITLE
Disable user namespaces in Droidspaces config

### DIFF
--- a/.github/actions/droidspaces/action.yml
+++ b/.github/actions/droidspaces/action.yml
@@ -81,5 +81,4 @@ runs:
           CONFIG_BINFMT_MISC=y
           CONFIG_BINFMT_SCRIPT=y
           CONFIG_BINFMT_ELF=y
-          CONFIG_USER_NS=y
-
+          CONFIG_USER_NS=n


### PR DESCRIPTION
Redo of #271 (merged PRs cannot be reopened on GitHub).

Same change as the original: flips CONFIG_USER_NS=y to CONFIG_USER_NS=n in .github/actions/droidspaces/action.yml.

DroidSpaces no longer requires User Namespaces; keeping the option enabled may indirectly indicate the kernel has been modified.

Supersedes: #271