### PR TITLE
fix: verify NoMount kernel integration

### DIFF
--- a/.github/actions/nomount/action.yml
+++ b/.github/actions/nomount/action.yml
@@ -72,6 +72,14 @@ runs:
           echo "NoMount integration failed: fs/nomount symlink missing" >&2
           exit 1
         fi
+        if ! grep -qxF 'obj-$(CONFIG_NOMOUNT) += nomount/' "$KERNEL_DIR/fs/Makefile"; then
+          echo "NoMount integration failed: fs/Makefile entry missing" >&2
+          exit 1
+        fi
+        if ! grep -qxF 'source "fs/nomount/Kconfig"' "$KERNEL_DIR/fs/Kconfig"; then
+          echo "NoMount integration failed: fs/Kconfig entry missing" >&2
+          exit 1
+        fi
 
         echo "commit=$actual_commit" >> "$GITHUB_OUTPUT"
         echo "NOMOUNT_COMMIT=$actual_commit" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- verify that the upstream NoMount setup script creates the fs/nomount symlink
- verify that it registers NoMount in fs/Makefile and fs/Kconfig

## Validation
- python3 .github/scripts/validate_workflows.py\n- python3 .github/scripts/validate_shell.py
- python3 .github/scripts/validate_python.py