### PR TITLE
fix: no sleep after final release upload retry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1398,8 +1398,10 @@ jobs:
               ok=true
               break
             fi
-            echo "Retry $attempt/3 failed for: $f" >&2
-            sleep 10
+            echo "Attempt $attempt/3 failed for: $f" >&2
+            if [ "$attempt" -lt 3 ]; then
+              sleep 10
+            fi
           done
           if [ "$ok" = false ]; then
             echo "ERROR: giving up on $f" >&2


### PR DESCRIPTION
Addresses https://github.com/WildKernels/GKI_KernelSU_SUSFS/pull/287#discussion_r3939457054 (Copilot): the retry loop slept even after the 3rd failed attempt and mislabeled the log line. Now sleeps only between attempts and logs Attempt n/3.