### PR TITLE
chore: bump PIN_NOMOUNT to dev tip 09f3c41f

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
           }
 
           # Audited pins (from root-variants.yml). Used only when commit_mode=verified.
-          PIN_NOMOUNT="7eb06026fe788ceea0f3c4de4a0b42ffa0a4cc99"
+          PIN_NOMOUNT="09f3c41f068977d96ff8e552327428a307f8d286"
           PIN_KERNELSU="3c1240625655978f319a98398031100b80e9da7c"
           PIN_RESUKISU="3c1882886dbbb54f4aae7ddf205f8ccde32c2a34"
           declare -A PIN_SUSFS=(


### PR DESCRIPTION
Upstream maxsteeel/nomount rewound dev: pinned 7eb06026 diverged from new tip 09f3c41f, fresh clones lack its tree, NoMount setup dies with 'fatal: unable to read tree' (exit 128) on all builds. Bump to current dev tip (kernel: changes exclusion list implementation).