### PR TITLE
fix: bump PIN_NOMOUNT to d0f57d5 and pre-fetch pin by SHA

### DIFF
--- a/.github/actions/nomount/action.yml
+++ b/.github/actions/nomount/action.yml
@@ -57,6 +57,15 @@ runs:
             --output "$setup_script"
           test -s "$setup_script"
           chmod 0755 "$setup_script"
+          # Pre-clone at the exact SHA: upstream rewinds dev often, so a
+          # fresh clone may no longer contain the pinned tree ("unable to
+          # read tree"). Fetching by SHA works even for orphaned commits;
+          # setup.sh then reuses the clone and its checkout succeeds.
+          if [ ! -d "$KERNEL_DIR/NoMount" ]; then
+            git clone --no-checkout https://github.com/maxsteeel/nomount.git "$KERNEL_DIR/NoMount"
+          fi
+          git -C "$KERNEL_DIR/NoMount" fetch --depth=1 origin "$requested_commit"
+          git -C "$KERNEL_DIR/NoMount" checkout --detach --quiet "$requested_commit"
           (
             cd "$KERNEL_DIR"
             "$setup_script" "$requested_commit"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
           }
 
           # Audited pins (from root-variants.yml). Used only when commit_mode=verified.
-          PIN_NOMOUNT="09f3c41f068977d96ff8e552327428a307f8d286"
+          PIN_NOMOUNT="d0f57d5c37ff02aae2299daded57919153240cb3"
           PIN_KERNELSU="3c1240625655978f319a98398031100b80e9da7c"
           PIN_RESUKISU="3c1882886dbbb54f4aae7ddf205f8ccde32c2a34"
           declare -A PIN_SUSFS=(


### PR DESCRIPTION
Upstream rewound dev again: 09f3c41f diverged from new tip d0f57d5, fresh clones lack its tree, NoMount setup dies with 'unable to read tree'. Bumps the pin and pre-clones/fetches the exact SHA before setup.sh runs, so the next rewind doesn't break us (fetch-by-SHA works even for orphaned commits, proven locally).