### PR TITLE
fix: chunk AnyKernel3 downloads per family + verify count

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1317,12 +1317,70 @@ jobs:
         merge-multiple: true
         if-no-files-found: ignore
 
-    - name: Download AnyKernel3 Artifacts
+    # NOTE: one download-artifact step per kernel family. A single
+    # pattern ('*-AnyKernel3') silently truncates: run 34015449465
+    # downloaded only 495/591 artifacts, so r20 shipped 500/596 assets.
+    - name: Download AnyKernel3 (5.10 android12)
       uses: actions/download-artifact@v7
       with:
         path: release-assets
-        pattern: '*-AnyKernel3'
+        pattern: '5.10.*-android12-*-AnyKernel3'
         merge-multiple: false
+
+    - name: Download AnyKernel3 (5.10 android13)
+      uses: actions/download-artifact@v7
+      with:
+        path: release-assets
+        pattern: '5.10.*-android13-*-AnyKernel3'
+        merge-multiple: false
+
+    - name: Download AnyKernel3 (5.15 android13)
+      uses: actions/download-artifact@v7
+      with:
+        path: release-assets
+        pattern: '5.15.*-android13-*-AnyKernel3'
+        merge-multiple: false
+
+    - name: Download AnyKernel3 (5.15 android14)
+      uses: actions/download-artifact@v7
+      with:
+        path: release-assets
+        pattern: '5.15.*-android14-*-AnyKernel3'
+        merge-multiple: false
+
+    - name: Download AnyKernel3 (6.1 android14)
+      uses: actions/download-artifact@v7
+      with:
+        path: release-assets
+        pattern: '6.1.*-android14-*-AnyKernel3'
+        merge-multiple: false
+
+    - name: Download AnyKernel3 (6.6 android15)
+      uses: actions/download-artifact@v7
+      with:
+        path: release-assets
+        pattern: '6.6.*-android15-*-AnyKernel3'
+        merge-multiple: false
+
+    - name: Download AnyKernel3 (6.12 android16)
+      uses: actions/download-artifact@v7
+      with:
+        path: release-assets
+        pattern: '6.12.*-android16-*-AnyKernel3'
+        merge-multiple: false
+
+    - name: Verify all AnyKernel3 artifacts downloaded
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        expected=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" --paginate --jq '.artifacts[].name' | grep -c '\-AnyKernel3$')
+        got=$(ls -d release-assets/*-AnyKernel3 2>/dev/null | wc -l)
+        echo "AnyKernel3 artifacts in run: $expected, downloaded: $got"
+        if [ "$got" -ne "$expected" ]; then
+          echo "ERROR: downloaded $got of $expected AnyKernel3 artifacts" >&2
+          exit 1
+        fi
 
     - name: Download NoMount metamodule
       uses: actions/download-artifact@v7


### PR DESCRIPTION
Single-pattern download-artifact silently truncated: run 34015449465 fetched 495/591 AnyKernel3 artifacts, so r20 shipped 500/596 assets (96 kernel zips missing). Splits the download into one step per kernel family and adds a count guard that fails the release job on any shortfall.