### PR TITLE
refactor: single-source release notes from preview artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -972,6 +972,7 @@ jobs:
     - build-android16-6-12
     - build-nomount-module
     - publish-manager-artifacts
+    - notes-preview
 
     env:
       GH_TOKEN: ${{ github.token }}
@@ -1145,7 +1146,9 @@ jobs:
         echo "KSU Git Tag: $KSU_GIT_TAG"
         echo "KSU Manager: $KSU_MANAGER"
 
-        # Export as environment for next step
+        # Exported for the release record; the notes themselves now come
+        # from the single release-notes-preview artifact (built by the
+        # notes-preview job from resolve-sources outputs).
         echo "KSUN_BRANCH=$KSU_INPUT" >> $GITHUB_ENV
         echo "KSUN_COMMIT=$KSUN_COMMIT" >> $GITHUB_ENV
         echo "KSU_COMMITS_COUNT=$COMMITS_COUNT" >> $GITHUB_ENV
@@ -1155,152 +1158,12 @@ jobs:
         echo "KSU_MANAGER_NOTE=${KSU_MANAGER_NOTE:-}" >> $GITHUB_ENV
         echo "MANAGER_RUN_ID=$MANAGER_RUN_ID" >> $GITHUB_ENV
 
-    - name: Set release body
-      env:
-        ROOT_FLAVOR: ${{ inputs.root_flavor }}
-        FEATURE_SET: ${{ needs.resolve-sources.outputs.feature_set }}
-        MANAGER_LIST: ${{ needs.resolve-sources.outputs.manager_list }}
-        ROOT_MATRIX: ${{ needs.resolve-sources.outputs.root_matrix }}
-        USE_SUSFS: ${{ inputs.use_susfs }}
-        USE_NOMOUNT: ${{ inputs.use_nomount }}
-        USE_BBG: ${{ inputs.use_bbg }}
-        USE_DS: ${{ inputs.use_ds }}
-        USE_NET: ${{ inputs.use_net }}
-        USE_NTSYNC: ${{ inputs.use_ntsync }}
-        USE_PTRACE: ${{ inputs.use_ptrace }}
-        USE_UNICODE: ${{ inputs.use_unicode }}
-        USE_BPF: ${{ inputs.use_bpf }}
-        USE_PERF: ${{ inputs.use_perf }}
-        USE_CACHE: ${{ inputs.use_cache }}
-        KERNEL_BUILD_VERSION: ${{ inputs.kernel_build_version }}
-        NOMOUNT_COMMIT: ${{ needs.resolve-sources.outputs.nomount_commit }}
-        KSU_COMMIT: ${{ needs.resolve-sources.outputs.ksu_commit }}
-        RESUKISU_COMMIT: ${{ needs.resolve-sources.outputs.resukisu_commit }}
-        KERNELSU_COMMIT: ${{ needs.resolve-sources.outputs.kernelsu_commit }}
-        KERNEL_PATCHES_COMMIT: ${{ needs.resolve-sources.outputs.kernel_patches_commit }}
-        ANYKERNEL3_COMMIT: ${{ needs.resolve-sources.outputs.anykernel3_commit }}
-        DROIDSPACES_COMMIT: ${{ needs.resolve-sources.outputs.droidspaces_commit }}
-        SUSFS_ANDROID12_5_10: ${{ needs.resolve-sources.outputs.susfs_commit_android12_5_10 }}
-        SUSFS_ANDROID13_5_10: ${{ needs.resolve-sources.outputs.susfs_commit_android13_5_10 }}
-        SUSFS_ANDROID13_5_15: ${{ needs.resolve-sources.outputs.susfs_commit_android13_5_15 }}
-        SUSFS_ANDROID14_5_15: ${{ needs.resolve-sources.outputs.susfs_commit_android14_5_15 }}
-        SUSFS_ANDROID14_6_1: ${{ needs.resolve-sources.outputs.susfs_commit_android14_6_1 }}
-        SUSFS_ANDROID15_6_6: ${{ needs.resolve-sources.outputs.susfs_commit_android15_6_6 }}
-        SUSFS_ANDROID16_6_12: ${{ needs.resolve-sources.outputs.susfs_commit_android16_6_12 }}
-        SUSFS_ANDROID12_5_10_RESUKISU: ${{ needs.resolve-sources.outputs.susfs_commit_android12_5_10_resukisu }}
-        SUSFS_ANDROID13_5_10_RESUKISU: ${{ needs.resolve-sources.outputs.susfs_commit_android13_5_10_resukisu }}
-        SUSFS_ANDROID13_5_15_RESUKISU: ${{ needs.resolve-sources.outputs.susfs_commit_android13_5_15_resukisu }}
-        SUSFS_ANDROID14_5_15_RESUKISU: ${{ needs.resolve-sources.outputs.susfs_commit_android14_5_15_resukisu }}
-        SUSFS_ANDROID14_6_1_RESUKISU: ${{ needs.resolve-sources.outputs.susfs_commit_android14_6_1_resukisu }}
-        SUSFS_ANDROID15_6_6_RESUKISU: ${{ needs.resolve-sources.outputs.susfs_commit_android15_6_6_resukisu }}
-        SUSFS_ANDROID16_6_12_RESUKISU: ${{ needs.resolve-sources.outputs.susfs_commit_android16_6_12_resukisu }}
-      run: |
-        set -e
-
-        : > release_body.md
-
-        python3 - <<'PYEOF' > release_body.md
-        import json, os
-        def env(n,d=""): return os.environ.get(n,d).strip() or d
-        def parse_managers(raw):
-            try: return json.loads(raw) if raw.strip() else []
-            except: return []
-        root = env("ROOT_FLAVOR","All")
-        feats=[]
-        if env("USE_SUSFS","true")=="true": feats.append("SUSFS")
-        if env("USE_NOMOUNT","true")=="true": feats.append("NoMount")
-        if env("USE_BBG","true")=="true": feats.append("Baseband Guard")
-        if env("USE_DS","true")=="true": feats.append("DroidSpaces-OSS")
-        if env("USE_NET","true")=="true": feats.append("Networking")
-        if env("USE_NTSYNC","true")=="true": feats.append("NTSync")
-        if env("USE_PTRACE","true")=="true": feats.append("Ptrace Leak Fix")
-        if env("USE_UNICODE","true")=="true": feats.append("Unicode Fix")
-        if env("USE_BPF","true")=="true": feats.append("BTF / eBPF / FUSE-BPF")
-        if env("USE_PERF","false")=="true": feats.append("Performance Tuning")
-        lines=[]
-        lines.append("# Wild Kernels for GKI2 Devices")
-        lines.append("")
-        lines.append("## Root")
-        lines.append("")
-        ksun_branch=env("KSUN_BRANCH","dev-susfs")
-        ksun_commit=env("KSUN_COMMIT","")
-        ksu_commit=env("KSU_COMMIT","")
-        resukisu_commit=env("RESUKISU_COMMIT","")
-        kernelsu_commit=env("KERNELSU_COMMIT","")
-        nm=env("NOMOUNT_COMMIT","")
-        kp=env("KERNEL_PATCHES_COMMIT","")
-        ak=env("ANYKERNEL3_COMMIT","")
-        ds=env("DROIDSPACES_COMMIT","")
-        _rmatrix={}
-        try: _rmatrix={m.get("root_flavor",""):m.get("root_commit","") for m in json.loads(env("ROOT_MATRIX","[]")) if isinstance(m,dict)}
-        except: pass
-        if env("USE_SUSFS","true")=="true":
-            _next_url="https://github.com/pershoot/KernelSU-Next/commit/"
-        else:
-            _next_url="https://github.com/KernelSU-Next/KernelSU-Next/commit/"
-        _root_urls={"next":_next_url,"kernelsu":"https://github.com/tiann/KernelSU/commit/","resukisu":"https://github.com/ReSukiSU/ReSukiSU/commit/"}
-        _root_commits={"next":_rmatrix.get("next","") or kernelsu_commit,"kernelsu":_rmatrix.get("kernelsu","") or ksu_commit,"resukisu":_rmatrix.get("resukisu","") or resukisu_commit}
-        _flavors0=[m.get("flavor","") for m in parse_managers(env("MANAGER_LIST","")) if m.get("flavor","")]
-        if not _flavors0:
-            _flavors0={"KernelSU-Next":["next"],"KernelSU":["kernelsu"],"ReSukiSU":["resukisu"],"All":["next","kernelsu","resukisu"]}.get(root,["next","kernelsu","resukisu"])
-        _labels0={"next":"KernelSU-Next","kernelsu":"KernelSU","resukisu":"ReSukiSU"}
-        _rc=[]
-        for _fl0 in _flavors0:
-            _c=_root_commits.get(_fl0,"")
-            if _c and len(_c)==40: _rc.append(f"{_labels0.get(_fl0,_fl0)} [`{_c[:7]}`]({_root_urls[_fl0]}{_c})")
-            elif _c: _rc.append(f"{_labels0.get(_fl0,_fl0)} `{_c}`")
-        for _r in _rc: lines.append(f"- {_r}")
-        lines.append("")
-        lines.append("## Features")
-        lines.append("")
-        _kp_url="https://github.com/WildKernels/kernel_patches/commit/"
-        _feat_commit={"NoMount":("https://github.com/maxsteeel/nomount/commit/",nm),"Baseband Guard":(_kp_url,kp),"DroidSpaces-OSS":("https://github.com/ravindu644/Droidspaces-OSS/commit/",ds)}
-        for f in feats:
-            _u,_c=_feat_commit.get(f,("",""))
-            if _c and len(_c)==40: lines.append(f"- {f} [`{_c[:7]}`]({_u}{_c})")
-            elif _c: lines.append(f"- {f} `{_c}`")
-            else: lines.append(f"- {f}")
-        if not feats: lines.append("- (none)")
-        kp=env("KERNEL_PATCHES_COMMIT","")
-        ak=env("ANYKERNEL3_COMMIT","")
-        ds=env("DROIDSPACES_COMMIT","")
-        lines.append("")
-        lines.append("## SUSFS commits")
-        lines.append("")
-        all_variants=["android12-5.10","android13-5.10","android13-5.15","android14-5.15","android14-6.1","android15-6.6","android16-6.12"]
-        def kbv_to_variant(kbv):
-            if ".x-android" in kbv:
-                kv, av = kbv.split(".x-android", 1)
-                v = f"android{av}-{kv}"
-                return v if v in all_variants else ""
-            return ""
-        kbv=env("KERNEL_BUILD_VERSION","All")
-        _sel=kbv_to_variant(kbv)
-        variants=[_sel] if _sel else list(all_variants)
-        sus_map={"android12-5.10":env("SUSFS_ANDROID12_5_10",""),"android13-5.10":env("SUSFS_ANDROID13_5_10",""),"android13-5.15":env("SUSFS_ANDROID13_5_15",""),"android14-5.15":env("SUSFS_ANDROID14_5_15",""),"android14-6.1":env("SUSFS_ANDROID14_6_1",""),"android15-6.6":env("SUSFS_ANDROID15_6_6",""),"android16-6.12":env("SUSFS_ANDROID16_6_12","")}
-        sus_map_resukisu={"android12-5.10":env("SUSFS_ANDROID12_5_10_RESUKISU",""),"android13-5.10":env("SUSFS_ANDROID13_5_10_RESUKISU",""),"android13-5.15":env("SUSFS_ANDROID13_5_15_RESUKISU",""),"android14-5.15":env("SUSFS_ANDROID14_5_15_RESUKISU",""),"android14-6.1":env("SUSFS_ANDROID14_6_1_RESUKISU",""),"android15-6.6":env("SUSFS_ANDROID15_6_6_RESUKISU",""),"android16-6.12":env("SUSFS_ANDROID16_6_12_RESUKISU","")}
-        _flavors=[m.get("flavor","") for m in parse_managers(env("MANAGER_LIST","")) if m.get("flavor","")]
-        if not _flavors:
-            _flavors={"KernelSU-Next":["next"],"KernelSU":["kernelsu"],"ReSukiSU":["resukisu"],"All":["next","kernelsu","resukisu"]}.get(root,["next","kernelsu","resukisu"])
-        _labels={"next":"KernelSU-Next","kernelsu":"KernelSU","resukisu":"ReSukiSU"}
-        _susfs_url="https://gitlab.com/simonpunk/susfs4ksu"
-        lines.append("| SUSFS branch |" + "".join(f" {_labels.get(_fl,_fl)} |" for _fl in _flavors))
-        lines.append("|---" * (len(_flavors) + 1) + "|")
-        for v in variants:
-            _row=f"| gki-{v} |"
-            for _fl in _flavors:
-                _sm=sus_map_resukisu if _fl=="resukisu" else sus_map
-                sha=_sm.get(v,"")
-                sha_s=f"[`{sha[:7]}`]({_susfs_url}/-/commit/{sha})" if sha else "_n/a_"
-                _row+=f" {sha_s} |"
-            lines.append(_row)
-        lines.append("")
-        lines.append("")
-        output="\n".join(lines)+"\n"
-        print(output,end="")
-        s=os.environ.get("GITHUB_STEP_SUMMARY")
-        if s: open(s,"a").write(output)
-        PYEOF
+    - name: Download release notes (single source)
+      uses: actions/download-artifact@v7
+      with:
+        name: release-notes-preview
+        path: .
+        if-no-files-found: error
 
     - name: Verify release body is populated
       run: |
@@ -1318,14 +1181,6 @@ jobs:
           exit 1
         fi
         echo "Release body OK ($(wc -l < release_body.md) lines)"
-
-    - name: Upload release notes artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: release-notes
-        path: release_body.md
-        retention-days: 7
-        if-no-files-found: error
 
     - name: Download Manager APK zips
       uses: actions/download-artifact@v7
@@ -1532,7 +1387,7 @@ jobs:
 
   notes-preview:
     if: always() && github.event_name == 'workflow_dispatch'
-    needs: [resolve-sources, build-android12-5-10, build-android13-5-10, build-android13-5-15, build-android14-5-15, build-android14-6-1, build-android15-6-6, build-android16-6-12, release]
+    needs: [resolve-sources, build-android12-5-10, build-android13-5-10, build-android13-5-15, build-android14-5-15, build-android14-6-1, build-android15-6-6, build-android16-6-12]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Drops the release job's duplicate notes generator (the one that shipped thin notes on r20). Flow is now: notes-preview renders release_body.md once from resolve-sources -> release job downloads that artifact, verifies it, and publishes it. One artifact, one body, no drift.