### PR TITLE
fix: fail release if NoMount metamodule zip missing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1289,6 +1289,19 @@ jobs:
           cd - >/dev/null
         done
 
+    - name: Verify NoMount metamodule zip
+      if: inputs.use_nomount
+      run: |
+        set -euo pipefail
+        # The metamodule silently missed r20 (artifact built fine, no zip
+        # on the release). Fail loud instead of shipping without it.
+        if ! ls release-assets/NoMount-Metamodule.zip >/dev/null 2>&1; then
+          echo "ERROR: use_nomount is true but release-assets/NoMount-Metamodule.zip is missing" >&2
+          ls release-assets/ >&2
+          exit 1
+        fi
+        echo "NoMount metamodule zip OK"
+
     - name: Create Release
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
r20 shipped without NoMount-Metamodule.zip even though the artifact built fine (uploaded by hand). Adds a conditional check that fails the release job when use_nomount is true but the zip is absent.